### PR TITLE
Make $constains do not return error on missing field

### DIFF
--- a/contains.go
+++ b/contains.go
@@ -21,6 +21,8 @@ func (o *ContainsOperator) Evaluate(conditions, data interface{}) (bool, error) 
 	if c, ok := conditions.(string); ok {
 		if d, ok := data.(string); ok {
 			return strings.Contains(d, c), nil
+		} else if data == nil {
+			return false, nil
 		}
 	}
 

--- a/contains_test.go
+++ b/contains_test.go
@@ -46,6 +46,12 @@ var _ = Describe("$contains", func() {
 				false,
 				false,
 			},
+			{
+				"not match a missing field",
+				`{"y":{"$contains":"xyz"}}`,
+				false,
+				false,
+			},
 		},
 	}
 


### PR DESCRIPTION
As $contains casts both the conditions and the data, it fails with error if the field is missing. Checking if the data is nil avoids this.